### PR TITLE
use files in package.json to avoid publishing .babelrc and other dev …

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-node_modules
-npm-debug.log
-yarn.lock

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "test": "babel-tape-runner test/*.js | tap-spec",
     "prepublish": "npm run build"
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "keywords": [],
   "license": "MIT",
   "dependencies": {},


### PR DESCRIPTION
…files to NPM. See https://github.com/cssinjs/jss/issues/673